### PR TITLE
Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ For Mac, `pyautogui` has a couple of extra requirements, which you can install w
 * Pray for it to work.
 
 # OBS Script
+Only tested for Windows. "Python scripting has never been officially supported on mac since we couldn't get it to work (also issues with the buildserver I believe). Doesn't appear that anybody has figured out why it didn't work or fixed it." (per [Rodney on OBS Forums](https://obsproject.com/forum/threads/python-scripting-dont-work-on-obs-22-0-3.99061/#post-386891))
+
 Instead of using s2v.py, it's possible to use OBS' built-in Python API (preferable atm). Set up take a little bit longer.
 
 * Open OBS and go to `Tools` > `Scripts` > `Python Settings` and there select the directory with your `python.exe`.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Script to convert Project Slippi replays into video using OBS
 
 # Requires
 * Python 3.6+ (`s2v.py` might work with a lesser version, but `obs_s2v.py` won't)
-* Windows. Untested on other platforms. Might work perfectly though, who knows.
+* Windows or Mac. Untested on other platforms. Might work perfectly though, who knows.
 * [Project Slippi desktop app](https://github.com/project-slippi/slippi-desktop-app/releases). Comes with a custom version of Dolphin, select this one when setting up your `config.py` or OBS script. Configure Dolphin as you like. If the changes are not getting saved, check that the folder is not read only or that you have permissions.
-* Install python dependencies.
+* Install python dependencies. For Windows:
 ```
 pip install py-slippi pyautogui
 ```
-[py-slippi](https://github.com/hohav/py-slippi) is under development, so you might need the git version (this script was writen using this [commit](https://github.com/hohav/py-slippi/tree/967973d9650247de541a2e20cfd727eea3a8331a))
+For Mac, `pyautogui` has a couple of extra requirements, which you can install with: `pip install -r requirements-mac.txt`. [py-slippi](https://github.com/hohav/py-slippi) is under development, so you might need the git version (this script was writen using this [commit](https://github.com/hohav/py-slippi/tree/967973d9650247de541a2e20cfd727eea3a8331a))
 ```pip install git+https://github.com/hohav/py-slippi --upgrade```
 * [OBS](https://obsproject.com/) (64 bits) installed. It also needs the `Stop recording` hotkey to be set to `CTRL+ALT+END` (default, can be changed on config.py, here is the [list with the key names](https://pyautogui.readthedocs.io/en/latest/keyboard.html#the-hotkey-function)). Also you need to configure obs the way you want to record the game, so create a scene and add Dolphin as source, etc...
 * Fill config.py with the paths to the replays folder, Dolphin.exe (Slippi), Super Smash Bros. Melee NTSC 1.02 version .iso and OBS64.

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,0 +1,10 @@
+Pillow==6.0.0
+py-slippi==1.3.0
+py-ubjson==0.13.0
+PyAutoGUI==0.9.44
+PyGetWindow==0.0.5
+PyMsgBox==1.0.6
+PyRect==0.1.4
+PyScreeze==0.1.21
+PyTweening==1.0.3
+termcolor==1.1.0

--- a/s2v.py
+++ b/s2v.py
@@ -1,4 +1,6 @@
+#!/usr/bin/env python
 import os
+import platform
 import time
 import math
 import json
@@ -15,8 +17,9 @@ replays_folder = CONFIG['replays_folder']
 dolphin = CONFIG['dolphin']
 melee = CONFIG['melee']
 obs_path = CONFIG['obs_path']
-obs_exe = 'obs64.exe'
-hotkey = CONFIG['hotkey'] # hotkey to stop recording OBS
+obs_exe = 'obs64.exe' if platform.system() == 'Windows' else './OBS'
+hotkey = CONFIG['hotkey']  # hotkey to stop recording OBS
+
 
 # Fetch replay data, load Slippi and records video
 def convert(replay):


### PR DESCRIPTION
the only real important change was `obs_exe = 'obs64.exe' if platform.system() == 'Windows' else './OBS'`. other than that there was some spacing changes, and some updates to the pip installation + README